### PR TITLE
Skip controls push for dependency bot PRs

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -32,12 +32,17 @@ jobs:
         LOG+=" - $(git log -1 --pretty=%B)"
         echo "$LOG" | cat - CHANGED > temp && mv temp CHANGED
     - name: git commit back
+      id: commit
+      if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' }}
       run: |
         git config --global user.email "action@github.com"
         git config --local user.name "GitHub Action"
-        git add  CHANGED ${CONTROLS_FILENAME} || true
-        git log -n1 --grep="^Automaitc updated controls" --format=format:%H | xargs -n 1 -i{} git log {}~1..HEAD --name-only --pretty=format: | grep -Eo '[0-9]{2}_.*.pm$|*.json$' && git commit CHANGED ${CONTROLS_FILENAME} -m "Automaitc updated controls and CHANGED" || true
+        git add CHANGED ${CONTROLS_FILENAME} || true
+        if git log -n1 --grep="^Automaitc updated controls" --format=format:%H | xargs -n 1 -i{} git log {}~1..HEAD --name-only --pretty=format: | grep -Eo '[0-9]{2}_.*.pm$|*.json$' && git commit CHANGED ${CONTROLS_FILENAME} -m "Automaitc updated controls and CHANGED"; then
+          echo "status=success" >> "$GITHUB_OUTPUT"
+        fi
     - name: git push
+      if: ${{ steps.commit.outputs.status }}
       uses: ad-m/github-push-action@v1.0.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Der Push in das Repo wird nicht ausgeführt, wenn es keinen commit gab.
Dadurch werden die pipeline nicht als Fehler daegestellt, wenn durch dependabot oder renovate ein PR erstellt wird.